### PR TITLE
Fixed Broken Imports

### DIFF
--- a/myproject/urls.py
+++ b/myproject/urls.py
@@ -15,7 +15,7 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path
-from django.conf.urls import include, url
+from django.conf.urls import include
 
 
 urlpatterns = [

--- a/templates/home.html
+++ b/templates/home.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% block content %}
 
-{% load static from staticfiles %}
+{% load static %}
 	<script src="{% static 'js/home.js' %}"> </script>
 	<link rel="stylesheet" type="text/css" href="{% static 'css/css/home.css' %}">
 

--- a/templates/show_page.html
+++ b/templates/show_page.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% block content %}
 
-{% load static from staticfiles %}
+{% load static %}
 <script src="{% static 'js/show_pages.js' %}"> </script>
 <div id="div">
 	

--- a/templates/show_pages.html
+++ b/templates/show_pages.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
-{% load static from staticfiles %}
+{% load static %}
 <div id="div" class="container-fluid">
 		<ul class="list-group">
     		{% for a in all_pages %}


### PR DESCRIPTION
Hi,

I was checking out your project and found that the latest versions of Django use different tagging calls than in your project.

In addition, the import for urls is no longer needed. 

https://stackoverflow.com/questions/55929472/django-templatesyntaxerror-staticfiles-is-not-a-registered-tag-library